### PR TITLE
fix typo in README.md channels/mmod -> channels/mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 - channels/log (ID van serveerster_log kanaal)
 - channels/roles (ID van self_roles kanaal)
 - channels/stats (ID van stats voice channel. Wordt automatisch aangemaakt met t!statssetup)
-- channels/mmod (ID van mod chat)
+- channels/mod (ID van mod chat)
 
 ## SQL
 ```


### PR DESCRIPTION
Laat me ff weten als de commits een bepaald formaat moeten hebben houd ik dat in de toekomst aan :)